### PR TITLE
Panel and metadata tables can be created and modified on the Get Started page

### DIFF
--- a/server/preprocessing.R
+++ b/server/preprocessing.R
@@ -392,6 +392,7 @@ plotPreprocessing <- function(sce) {
     if (feature == "all") {
       feature <- NULL
     }
+    if(nrow(ei(sce)) > 2){
     reactiveVals$mdsPlot <- CATALYST::pbMDS(
       sce,
       label_by = input$mdsLabelBy,
@@ -399,6 +400,10 @@ plotPreprocessing <- function(sce) {
       features = feature,
       assay = input$mdsAssay,
     )
+    }else{
+      reactiveVals$mdsPlot <- ggplot() + theme_void()
+      showNotification('MDS is only possible for >2 samples', type = 'warning')
+    }
     reactiveVals$mdsPlot
     
   })


### PR DESCRIPTION
New feature. The panel can now be 

- created from all columns of the fcs files
- edited after being guessed automatically
- expanded or reduced (rows can be added and deleted)
- reset if there was a mistake

The metadata can now be 

- Created from the fcs files
- expanded or decreased (columns can be added and deleted)

Both the panel and the metadata table can be downloaded now. This also works for the example data. 